### PR TITLE
Add logprob support for Responses API

### DIFF
--- a/docs/ja/models/index.md
+++ b/docs/ja/models/index.md
@@ -103,7 +103,7 @@ OpenAI の Responses API を使用する場合、`user` や `service_tier` な�
 ```python
 from agents import Agent, ModelSettings
 
-english_agent = Agent(
+ english_agent = Agent(
     name="English agent",
     instructions="You only speak English",
     model="gpt-4o",
@@ -111,6 +111,20 @@ english_agent = Agent(
         temperature=0.1,
         extra_args={"service_tier": "flex", "user": "user_12345"},
     ),
+)
+```
+
+Responses API でトークンの対数確率を取得したい場合は、
+`ModelSettings` の `top_logprobs` を設定してください。
+
+```python
+from agents import Agent, ModelSettings
+
+agent = Agent(
+    name="English agent",
+    instructions="You only speak English",
+    model="gpt-4o",
+    model_settings=ModelSettings(top_logprobs=2),
 )
 ```
 

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -109,6 +109,20 @@ english_agent = Agent(
 )
 ```
 
+You can also request token log probabilities when using the Responses API by
+setting `top_logprobs` in `ModelSettings`.
+
+```python
+from agents import Agent, ModelSettings
+
+agent = Agent(
+    name="English agent",
+    instructions="You only speak English",
+    model="gpt-4o",
+    model_settings=ModelSettings(top_logprobs=2),
+)
+```
+
 ## Common issues with using other LLM providers
 
 ### Tracing client error 401

--- a/src/agents/model_settings.py
+++ b/src/agents/model_settings.py
@@ -17,9 +17,9 @@ from typing_extensions import TypeAlias
 class _OmitTypeAnnotation:
     @classmethod
     def __get_pydantic_core_schema__(
-            cls,
-            _source_type: Any,
-            _handler: GetCoreSchemaHandler,
+        cls,
+        _source_type: Any,
+        _handler: GetCoreSchemaHandler,
     ) -> core_schema.CoreSchema:
         def validate_from_none(value: None) -> _Omit:
             return _Omit()
@@ -39,12 +39,13 @@ class _OmitTypeAnnotation:
                     from_none_schema,
                 ]
             ),
-            serialization=core_schema.plain_serializer_function_ser_schema(
-                lambda instance: None
-            ),
+            serialization=core_schema.plain_serializer_function_ser_schema(lambda instance: None),
         )
+
+
 Omit = Annotated[_Omit, _OmitTypeAnnotation]
 Headers: TypeAlias = Mapping[str, Union[str, Omit]]
+
 
 @dataclass
 class ModelSettings:
@@ -106,6 +107,10 @@ class ModelSettings:
     response_include: list[ResponseIncludable] | None = None
     """Additional output data to include in the model response.
     [include parameter](https://platform.openai.com/docs/api-reference/responses/create#responses-create-include)"""
+
+    top_logprobs: int | None = None
+    """Number of top tokens to return logprobs for. Setting this will
+    automatically include ``"message.output_text.logprobs"`` in the response."""
 
     extra_query: Query | None = None
     """Additional query fields to provide with the request.

--- a/tests/model_settings/test_serialization.py
+++ b/tests/model_settings/test_serialization.py
@@ -47,6 +47,7 @@ def test_all_fields_serialization() -> None:
         store=False,
         include_usage=False,
         response_include=["reasoning.encrypted_content"],
+        top_logprobs=1,
         extra_query={"foo": "bar"},
         extra_body={"foo": "bar"},
         extra_headers={"foo": "bar"},
@@ -135,8 +136,8 @@ def test_extra_args_resolve_both_none() -> None:
     assert resolved.temperature == 0.5
     assert resolved.top_p == 0.9
 
-def test_pydantic_serialization() -> None:
 
+def test_pydantic_serialization() -> None:
     """Tests whether ModelSettings can be serialized with Pydantic."""
 
     # First, lets create a ModelSettings instance
@@ -153,6 +154,7 @@ def test_pydantic_serialization() -> None:
         metadata={"foo": "bar"},
         store=False,
         include_usage=False,
+        top_logprobs=1,
         extra_query={"foo": "bar"},
         extra_body={"foo": "bar"},
         extra_headers={"foo": "bar"},

--- a/tests/test_logprobs.py
+++ b/tests/test_logprobs.py
@@ -1,0 +1,50 @@
+import pytest
+from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+from agents import ModelSettings, ModelTracing, OpenAIResponsesModel
+
+
+class DummyResponses:
+    async def create(self, **kwargs):
+        self.kwargs = kwargs
+
+        class DummyResponse:
+            id = "dummy"
+            output = []
+            usage = type(
+                "Usage",
+                (),
+                {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "total_tokens": 0,
+                    "input_tokens_details": InputTokensDetails(cached_tokens=0),
+                    "output_tokens_details": OutputTokensDetails(reasoning_tokens=0),
+                },
+            )()
+
+        return DummyResponse()
+
+
+class DummyClient:
+    def __init__(self):
+        self.responses = DummyResponses()
+
+
+@pytest.mark.allow_call_model_methods
+@pytest.mark.asyncio
+async def test_top_logprobs_param_passed():
+    client = DummyClient()
+    model = OpenAIResponsesModel(model="gpt-4", openai_client=client)  # type: ignore
+    await model.get_response(
+        system_instructions=None,
+        input="hi",
+        model_settings=ModelSettings(top_logprobs=2),
+        tools=[],
+        output_schema=None,
+        handoffs=[],
+        tracing=ModelTracing.DISABLED,
+        previous_response_id=None,
+    )
+    assert client.responses.kwargs["top_logprobs"] == 2
+    assert "message.output_text.logprobs" in client.responses.kwargs["include"]


### PR DESCRIPTION
## Summary
- expose `top_logprobs` on `ModelSettings`
- automatically request token logprobs in `OpenAIResponsesModel`
- document how to enable logprobs
- test passing `top_logprobs`

## Testing
- `make format`
- `make lint`
- `make mypy`
- `make tests`
- `make build-docs`


------
https://chatgpt.com/codex/tasks/task_e_685fbd37eb548332adccd7e38487b783